### PR TITLE
Create a new WriteCloser that will check before writing if connection is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ No releases but `master` will remain stable™.
 
 **Changelog**
 
+* 2020-11-13 - Added the SafeConn write closer that checks if the connection is still up before attempting to write
+
 * 2020-08-27 - Fixed bug in `statsd.Tags` identified by https://github.com/alexcesaro/statsd/issues/41
 
 * 2019-05-22 - Added support for arbitrary output streams via new `statsd.WriteCloser` option

--- a/safeconn.go
+++ b/safeconn.go
@@ -1,0 +1,59 @@
+package statsd
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	timeoutDuration = 10 * time.Millisecond
+)
+
+// SafeConn is an implementation of the io.WriteCloser that wraps a net.Conn type
+// its purpose is to perform a guard as a part of each Write call to first check if
+// the connection is still up by performing a small read. The use case of this is to
+// protect against the case where a TCP connection comes disconnected and the Write
+// continues to retry for up to 15 minutes before determining that the connection has
+// been broken off.
+type SafeConn struct {
+	netConn net.Conn
+}
+
+func NewSafeConn(network string, address string) (*SafeConn, error) {
+	newConn, err := dialTimeout(network, address, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &SafeConn{
+		netConn: newConn,
+	}
+
+	return c, nil
+}
+
+func (s *SafeConn) Write(p []byte) (n int, err error) {
+	// check if connection is closed
+	if s.connIsClosed() {
+		return 0, fmt.Errorf("connection is closed")
+	}
+
+	return s.netConn.Write(p)
+}
+
+func (s *SafeConn) Close() error {
+	return s.netConn.Close()
+}
+
+func (s *SafeConn) connIsClosed() bool {
+	err := s.netConn.SetReadDeadline(time.Now().Add(timeoutDuration))
+	if err != nil {
+		return true
+	}
+
+	one := make([]byte, 1)
+	_, err = s.netConn.Read(one)
+	return err == io.EOF
+}

--- a/safeconn_test.go
+++ b/safeconn_test.go
@@ -1,0 +1,123 @@
+package statsd
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+type mockNetConn struct {
+	read             func(p []byte) (n int, err error)
+	write            func(p []byte) (n int, err error)
+	close            func() error
+	localAddr        func() net.Addr
+	remoteAddr       func() net.Addr
+	setDeadline      func(t time.Time) error
+	setReadDeadline  func(t time.Time) error
+	setWriteDeadline func(t time.Time) error
+}
+
+func (m *mockNetConn) Read(p []byte) (n int, err error) {
+	if m.read != nil {
+		return m.read(p)
+	}
+	panic("implement me")
+}
+
+func (m *mockNetConn) Write(p []byte) (n int, err error) {
+	if m.write != nil {
+		return m.write(p)
+	}
+	panic("implement me")
+}
+
+func (m *mockNetConn) Close() error {
+	if m.close != nil {
+		return m.close()
+	}
+	panic("implement me")
+}
+
+func (m *mockNetConn) LocalAddr() net.Addr {
+	if m.localAddr != nil {
+		return m.localAddr()
+	}
+	panic("implement me")
+}
+
+func (m *mockNetConn) RemoteAddr() net.Addr {
+	if m.remoteAddr != nil {
+		return m.remoteAddr()
+	}
+	panic("implement me")
+}
+
+func (m *mockNetConn) SetDeadline(t time.Time) error {
+	if m.setDeadline != nil {
+		return m.setDeadline(t)
+	}
+	panic("implement me")
+}
+
+func (m *mockNetConn) SetReadDeadline(t time.Time) error {
+	if m.setReadDeadline != nil {
+		return m.setReadDeadline(t)
+	}
+	panic("implement me")
+}
+
+func (m *mockNetConn) SetWriteDeadline(t time.Time) error {
+	if m.setWriteDeadline != nil {
+		return m.setWriteDeadline(t)
+	}
+	panic("implement me")
+}
+
+func TestSafeConn_FailsToWriteIfCannotRead(t *testing.T) {
+	c := &mockNetConn{
+		setReadDeadline: func(t time.Time) error {
+			return nil
+		},
+		read: func(b []byte) (int, error) {
+			return 0, io.EOF
+		},
+	}
+
+	s := SafeConn{
+		netConn: c,
+	}
+
+	p := []byte("test_key:1|c\n")
+	n, err := s.Write(p)
+	if n != 0 {
+		t.Error("Write() did not return 0 bytes when it failed")
+	}
+	if err == nil {
+		t.Error("Error should have been connection is closed")
+	}
+}
+
+func TestSafeConn_SuccessfullyWritesWhenConnectionOpen(t *testing.T) {
+	c := &mockNetConn{
+		setReadDeadline: func(t time.Time) error {
+			return nil
+		},
+		read: func(b []byte) (int, error) {
+			return 1, nil
+		},
+		write: func(b []byte) (int, error) {
+			return len(b), nil
+		},
+	}
+
+	s := SafeConn{
+		netConn: c,
+	}
+
+	p := []byte("test_key:1|c\n")
+	_, err := s.Write(p)
+	if err != nil {
+		t.Errorf("Error should have been nil, but instead it was: %v", err)
+	}
+}


### PR DESCRIPTION
It is possible that the TCP connection has become disconnected. This is very common at deployment time for k8s clusters where there might be multiple statsd service pods and the clients that are using these endpoints may be created before their statsd service counterparts. This means that shortly after the clients are initialized, they start to fail to send metrics, but the client doesn't see an error because TCP will continue to retry for about 15 minutes before determining that the connection has been broken off. By checking before attempting to send the packets if we are able to read on the buffer, we can know that the connection has been broken as soon as the next metric is about to be sent and fail then.

Summary of changes:

- Create a new implementation of `io.WriteCloser` that wraps `net.Conn` to perform a read prior to attempting to perform a `Write()`. 
- updated the timeline in the README to include these changes


How to use the `SafeConn` write closer:

before creating the statsd client, run a command like this:
```golang
writeCloser, _ := statsd.NewSafeConnWithDefaultTimeout("tcp", endpoint)
client, err := statsd.New(
    statsd.WriteCloser(writeCloser),
)
```

This new PR is based on the feedback from my original PR to maintain the functionality of the original library without causing a breaking change.
