### PR TITLE
Change the repository to support go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ No releases but `master` will remain stable™.
 
 **Changelog**
 
+* 2020-11-13 - Added support for go modules
+
 * 2020-08-27 - Fixed bug in `statsd.Tags` identified by https://github.com/alexcesaro/statsd/issues/41
 
 * 2019-05-22 - Added support for arbitrary output streams via new `statsd.WriteCloser` option
@@ -46,7 +48,7 @@ https://godoc.org/gopkg.in/alexcesaro/statsd.v2
 
 ## Download
 
-    go get gopkg.in/alexcesaro/statsd.v2
+    go get github.com/joeycumines/statsd
 
 
 ## Example

--- a/examples_test.go
+++ b/examples_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"gopkg.in/alexcesaro/statsd.v2"
+	"github.com/joeycumines/statsd"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/joeycumines/statsd
+
+go 1.14


### PR DESCRIPTION
Added the `go.mod` file and changed the `gopkg.in/alexcesaro/statsd.v2` usage in `examples_test.go` to use the `github.com/joeycumines/statsd`module instead